### PR TITLE
fix MaxIdleTimeout of quic.Config

### DIFF
--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -118,7 +118,7 @@ func (q *quicTransport) Dial(addr string, opts ...transport.DialOption) (transpo
 		}
 	}
 	s, err := quic.DialAddr(addr, config, &quic.Config{
-		IdleTimeout: time.Minute * 2,
+		MaxIdleTimeout: time.Minute * 2,
 		KeepAlive:   true,
 	})
 	if err != nil {


### PR DESCRIPTION
Refer to  the [commit ](https://github.com/lucas-clemente/quic-go/commit/2828fbc1afb587df356106597d2de15f668a3c5e)  of https://github.com/lucas-clemente/quic-go,  the quic.Config changed the field IdleTimeout to MaxIdleTimeout.